### PR TITLE
Enable svg suppert in next image config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,13 @@ const nextConfig: NextConfig = {
   /* config options here */
   reactCompiler: true,
   images: {
+
+    dangerouslyAllowSVG: true,
+    contentDispositionType: 'attachment',
+    contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
+    
     remotePatterns: [
+      
       {
         protocol: 'https',
         hostname: 'placehold.co',


### PR DESCRIPTION
Updates Next config file (next.config.ts) to allow SVG images with CSP and attachment disposition, without losing Next Image tag optimization.

## Testing
- Run client and server with npm run dev:full
- Go to http:/localhost:3000/shop
- Bug does not show in console

Fixes bug:

<img width="1061" height="53" alt="Skärmavbild 2026-04-16 kl  10 35 26" src="https://github.com/user-attachments/assets/5cb8039c-fc8b-457e-a516-e76fb5da444d" />
